### PR TITLE
[FEATURE] Introduce endpoint for stability badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Endpoint: `/badge/{extension}/extension`
 
 ![TYPO3 extension](https://shields.io/endpoint?url=https://badges.typo3-web.dev/badge/handlebars/extension)
 
+### Badge for extension stability
+
+Endpoint: `/badge/{extension}/stability`
+
+**Example (Markdown):**
+
+```markdown
+![Stability](https://shields.io/endpoint?url=https://badges.typo3-web.dev/badge/handlebars/stability)
+```
+
+**Result:**
+
+![Stability](https://shields.io/endpoint?url=https://badges.typo3-web.dev/badge/handlebars/stability)
+
 ### Generic TYPO3 badge
 
 Endpoint: `/badge/typo3`

--- a/src/Controller/StabilityBadgeController.php
+++ b/src/Controller/StabilityBadgeController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2021 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Controller;
+
+use App\Http\BadgeResponse;
+use App\Service\ApiService;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * StabilityBadgeController.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Route(
+    path: '/badge/{extension}/stability',
+    name: 'badge.stability',
+    requirements: ['extension' => '[a-z0-9_]+'],
+    methods: ['GET'],
+)]
+final class StabilityBadgeController
+{
+    public function __construct(
+        private ApiService $apiService,
+    ) {
+    }
+
+    public function __invoke(string $extension): Response
+    {
+        $apiResponse = $this->apiService->getExtensionMetadata($extension);
+        $stability = $apiResponse[0]['current_version']['state']
+            ?? throw new BadRequestHttpException('Invalid API response.');
+
+        return BadgeResponse::forStability($stability)->create();
+    }
+}

--- a/src/Http/BadgeResponse.php
+++ b/src/Http/BadgeResponse.php
@@ -39,6 +39,13 @@ final class BadgeResponse
         'version' => 'orange',
         'downloads' => 'blue',
         'error' => 'red',
+        'stability_stable' => 'green',
+        'stability_beta' => 'yellow',
+        'stability_alpha' => 'red',
+        'stability_experimental' => 'red',
+        'stability_test' => 'lightgrey',
+        'stability_obsolete' => 'lightgrey',
+        'stability_excludeFromUpdates' => 'lightgrey',
     ];
 
     private string $label = '';
@@ -72,6 +79,16 @@ final class BadgeResponse
         $object->label = 'typo3';
         $object->message = sprintf('%s downloads', strtolower(NumberFormatter::format($downloads)));
         $object->color = self::COLOR_MAP['downloads'];
+
+        return $object;
+    }
+
+    public static function forStability(string $stability): self
+    {
+        $object = new self();
+        $object->label = 'typo3';
+        $object->message = $stability;
+        $object->color = self::COLOR_MAP['stability_'.$stability] ?? 'orange';
 
         return $object;
     }

--- a/templates/homepage.html.twig
+++ b/templates/homepage.html.twig
@@ -74,6 +74,11 @@
                 {% block badgeLabel %}TYPO3 extension{% endblock %}
             {% endembed %}
 
+            {% embed '_endpoint.html.twig' with {'routeName': 'badge.stability', 'routeParameters': {'extension': 'handlebars'}, 'routes': routes} %}
+                {% block description %}Get JSON data for extension stability.{% endblock %}
+                {% block badgeLabel %}Stability{% endblock %}
+            {% endembed %}
+
             {% embed '_endpoint.html.twig' with {'routeName': 'badge.default', 'routeParameters': {}, 'routes': routes} %}
                 {% block description %}Get JSON data for a generic TYPO3 badge.{% endblock %}
                 {% block badgeLabel %}TYPO3{% endblock %}

--- a/tests/Controller/StabilityBadgeControllerTest.php
+++ b/tests/Controller/StabilityBadgeControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2021 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Controller\StabilityBadgeController;
+use App\Tests\AbstractApiTestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * StabilityBadgeControllerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class StabilityBadgeControllerTest extends AbstractApiTestCase
+{
+    private StabilityBadgeController $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new StabilityBadgeController($this->apiService);
+    }
+
+    /**
+     * @test
+     */
+    public function controllerThrowsBadRequestExceptionIfApiResponseIsInvalid(): void
+    {
+        $this->mockResponses[] = new MockResponse(json_encode(['foo' => 'baz']));
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectErrorMessage('Invalid API response.');
+
+        $this->subject->__invoke('foo');
+    }
+
+    /**
+     * @test
+     * @dataProvider controllerReturnsBadgeForGivenExtensionDataProvider
+     */
+    public function controllerReturnsBadgeForGivenExtension(string $state, string $expectedColor): void
+    {
+        $this->mockResponses[] = new MockResponse(json_encode([
+            [
+                'current_version' => [
+                    'state' => $state,
+                ],
+            ],
+        ]));
+
+        $expected = new JsonResponse([
+            'schemaVersion' => 1,
+            'label' => 'typo3',
+            'message' => $state,
+            'color' => $expectedColor,
+            'isError' => false,
+            'namedLogo' => 'typo3',
+        ]);
+
+        self::assertEquals($expected, $this->subject->__invoke('foo'));
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public function controllerReturnsBadgeForGivenExtensionDataProvider(): \Generator
+    {
+        yield 'stable' => ['stable', 'green'];
+        yield 'beta' => ['beta', 'yellow'];
+        yield 'alpha' => ['alpha', 'red'];
+        yield 'experimental' => ['experimental', 'red'];
+        yield 'test' => ['test', 'lightgrey'];
+        yield 'obsolete' => ['obsolete', 'lightgrey'];
+        yield 'excludeFromUpdates' => ['excludeFromUpdates', 'lightgrey'];
+    }
+}

--- a/tests/Http/BadgeResponseTest.php
+++ b/tests/Http/BadgeResponseTest.php
@@ -91,6 +91,25 @@ final class BadgeResponseTest extends TestCase
 
     /**
      * @test
+     * @dataProvider forStabilityReturnsResponseForStabilityDataProvider
+     */
+    public function forStabilityReturnsResponseForStability(string $stability, string $expectedColor): void
+    {
+        $subject = BadgeResponse::forStability($stability);
+        $expected = new JsonResponse([
+            'schemaVersion' => 1,
+            'label' => 'typo3',
+            'message' => $stability,
+            'color' => $expectedColor,
+            'isError' => false,
+            'namedLogo' => 'typo3',
+        ]);
+
+        self::assertEquals($expected, $subject->create());
+    }
+
+    /**
+     * @test
      */
     public function forErrorReturnsResponseOnError(): void
     {
@@ -123,5 +142,19 @@ final class BadgeResponseTest extends TestCase
         ]);
 
         self::assertEquals($expected, $subject->create());
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public function forStabilityReturnsResponseForStabilityDataProvider(): \Generator
+    {
+        yield 'stable' => ['stable', 'green'];
+        yield 'beta' => ['beta', 'yellow'];
+        yield 'alpha' => ['alpha', 'red'];
+        yield 'experimental' => ['experimental', 'red'];
+        yield 'test' => ['test', 'lightgrey'];
+        yield 'obsolete' => ['obsolete', 'lightgrey'];
+        yield 'excludeFromUpdates' => ['excludeFromUpdates', 'lightgrey'];
     }
 }


### PR DESCRIPTION
This PR introduces an endpoint for extension stability badges:

```
GET /badge/{extension}/stability
```