### PR TITLE
[FEATURE] Enable GitHub's automatic generation of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - 'good first issue'
+      - 'help wanted'
+      - invalid
+      - question
+      - wontfix
+  categories:
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: ⚡ Breaking
+      labels:
+        - breaking
+    - title: 🚀 Improved
+      labels:
+        - enhancement
+    - title: 🚑 Fixed
+      labels:
+        - bug
+    - title: ⚙️ Dependencies
+      labels:
+        - dependencies
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,34 +23,9 @@ jobs:
             exit 1
           fi
 
-      # Create Changelog
-      - name: Create changelog
-        id: create-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          addSections: '{"documentation":{"prefix":"### Documentation","labels":["documentation"]},"feature":{"prefix":"### Added","labels":["feature"]},"dependencies":{"prefix":"### Changes","labels":["dependencies"]}}'
-          breakingLabel: "### Breaking"
-          enhancementLabel: "### Changed"
-          bugsLabel: "### Fixed"
-          deprecatedLabel: "### Deprecated"
-          removedLabel: "### Removed"
-          securityLabel: "### Security"
-          prLabel: "### Other pull requests"
-          onlyLastTag: true
-          issues: false
-          issuesWoLabels: false
-          pullRequests: true
-          prWoLabels: true
-          stripHeaders: false
-          stripGeneratorNotice: true
-      - name: Print changelog to console
-        run: cat CHANGELOG.md
-
       # Create release
       - name: Create release
         id: create-release
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: ${{ steps.create-changelog.outputs.changelog }}
+          generate_release_notes: true


### PR DESCRIPTION
This PR enables GitHub's [automatic generation of release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). Release notes will no longer generated manually in CI, but rather automatically via GitHub. An appropriate release notes configuration has been added.