### PR TITLE
[!!!][FEATURE] Enable basic HTTP caching and use Symfony's reverse proxy

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -26,6 +26,7 @@ framework:
 when@prod:
     framework:
         error_controller: App\Controller\ErrorController
+        http_cache: true
 
 when@test:
     framework:

--- a/src/Controller/DownloadsBadgeController.php
+++ b/src/Controller/DownloadsBadgeController.php
@@ -52,10 +52,14 @@ final class DownloadsBadgeController extends AbstractBadgeController
 
     public function __invoke(Request $request, string $extension, string $provider = null): Response
     {
-        $apiResponse = $this->apiService->getExtensionMetadata($extension);
-        $downloads = $apiResponse[0]['downloads']
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $downloads = $extensionMetadata[0]['downloads']
             ?? throw new BadRequestHttpException('Invalid API response.');
 
-        return $this->getBadgeResponse(Badge::forDownloads($downloads), $provider);
+        return $this->getBadgeResponse(
+            Badge::forDownloads($downloads),
+            $provider,
+            $extensionMetadata->getExpiryDate(),
+        );
     }
 }

--- a/src/Controller/ExtensionBadgeController.php
+++ b/src/Controller/ExtensionBadgeController.php
@@ -52,10 +52,14 @@ final class ExtensionBadgeController extends AbstractBadgeController
 
     public function __invoke(Request $request, string $extension, string $provider = null): Response
     {
-        $apiResponse = $this->apiService->getExtensionMetadata($extension);
-        $extensionKey = $apiResponse[0]['key']
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $extensionKey = $extensionMetadata[0]['key']
             ?? throw new BadRequestHttpException('Invalid API response.');
 
-        return $this->getBadgeResponse(Badge::forExtension($extensionKey), $provider);
+        return $this->getBadgeResponse(
+            Badge::forExtension($extensionKey),
+            $provider,
+            $extensionMetadata->getExpiryDate(),
+        );
     }
 }

--- a/src/Controller/StabilityBadgeController.php
+++ b/src/Controller/StabilityBadgeController.php
@@ -52,10 +52,14 @@ final class StabilityBadgeController extends AbstractBadgeController
 
     public function __invoke(Request $request, string $extension, string $provider = null): Response
     {
-        $apiResponse = $this->apiService->getExtensionMetadata($extension);
-        $stability = $apiResponse[0]['current_version']['state']
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $stability = $extensionMetadata[0]['current_version']['state']
             ?? throw new BadRequestHttpException('Invalid API response.');
 
-        return $this->getBadgeResponse(Badge::forStability($stability), $provider);
+        return $this->getBadgeResponse(
+            Badge::forStability($stability),
+            $provider,
+            $extensionMetadata->getExpiryDate(),
+        );
     }
 }

--- a/src/Controller/VersionBadgeController.php
+++ b/src/Controller/VersionBadgeController.php
@@ -52,10 +52,14 @@ final class VersionBadgeController extends AbstractBadgeController
 
     public function __invoke(Request $request, string $extension, string $provider = null): Response
     {
-        $apiResponse = $this->apiService->getExtensionMetadata($extension);
-        $version = $apiResponse[0]['current_version']['number']
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $version = $extensionMetadata[0]['current_version']['number']
             ?? throw new BadRequestHttpException('Invalid API response.');
 
-        return $this->getBadgeResponse(Badge::forVersion($version), $provider);
+        return $this->getBadgeResponse(
+            Badge::forVersion($version),
+            $provider,
+            $extensionMetadata->getExpiryDate()
+        );
     }
 }

--- a/src/Entity/Dto/ExtensionMetadata.php
+++ b/src/Entity/Dto/ExtensionMetadata.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Entity\Dto;
+
+/**
+ * ExtensionMetadata.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @implements \ArrayAccess<int|string, mixed>
+ */
+final class ExtensionMetadata implements \ArrayAccess
+{
+    public function __construct(
+        /**
+         * @var array<int|string, mixed>
+         */
+        private array $metadata,
+        private ?\DateTime $expiryDate = null,
+    ) {
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function getExpiryDate(): ?\DateTime
+    {
+        return $this->expiryDate;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->metadata[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->metadata[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->metadata[$offset] = $value;
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->metadata[$offset]);
+    }
+}

--- a/tests/Controller/AbstractBadgeControllerTest.php
+++ b/tests/Controller/AbstractBadgeControllerTest.php
@@ -78,4 +78,19 @@ final class AbstractBadgeControllerTest extends KernelTestCase
 
         self::assertEquals($expected, $this->subject->testGetBadgeResponse($badge, 'badgen'));
     }
+
+    /**
+     * @test
+     */
+    public function getBadgeResponseReturnsCachedResponse(): void
+    {
+        $badge = new Badge();
+        $cacheExpirationDate = new \DateTime();
+        $expected = $this->badgeProviderFactory->get('badgen')->createResponse($badge)
+            ->setPublic()
+            ->setExpires($cacheExpirationDate);
+        $expected->headers->addCacheControlDirective('must-revalidate', true);
+
+        self::assertEquals($expected, $this->subject->testGetBadgeResponse($badge, 'badgen', $cacheExpirationDate));
+    }
 }

--- a/tests/Entity/Dto/ExtensionMetadataTest.php
+++ b/tests/Entity/Dto/ExtensionMetadataTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Tests\Entity\Dto;
+
+use App\Entity\Dto\ExtensionMetadata;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ExtensionMetadataTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ExtensionMetadataTest extends TestCase
+{
+    private \DateTime $expiryDate;
+    private ExtensionMetadata $subject;
+
+    protected function setUp(): void
+    {
+        $this->expiryDate = new \DateTime();
+        $this->subject = new ExtensionMetadata(['foo' => 'baz'], $this->expiryDate);
+    }
+
+    /**
+     * @test
+     */
+    public function getMetadataReturnsExtensionMetadata(): void
+    {
+        self::assertSame(['foo' => 'baz'], $this->subject->getMetadata());
+    }
+
+    /**
+     * @test
+     */
+    public function getExpiryDateReturnsExpiryDate(): void
+    {
+        self::assertSame($this->expiryDate, $this->subject->getExpiryDate());
+    }
+
+    /**
+     * @test
+     */
+    public function subjectCanBeAccessedAsArray(): void
+    {
+        // offsetExists()
+        self::assertTrue(isset($this->subject['foo']));
+        self::assertFalse(isset($this->subject['baz']));
+
+        // offsetGet()
+        self::assertSame('baz', $this->subject['foo']);
+        self::assertNull($this->subject['baz']);
+
+        // offsetSet()
+        $this->subject['baz'] = 'foo';
+        self::assertSame('foo', $this->subject['baz']);
+
+        // offsetUnset()
+        unset($this->subject['baz']);
+        self::assertFalse(isset($this->subject['baz']));
+    }
+}

--- a/tests/Fixtures/AbstractBadgeControllerTestClass.php
+++ b/tests/Fixtures/AbstractBadgeControllerTestClass.php
@@ -37,8 +37,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class AbstractBadgeControllerTestClass extends AbstractBadgeController
 {
-    public function testGetBadgeResponse(Badge $badge, string $provider = null): Response
-    {
-        return $this->getBadgeResponse($badge, $provider);
+    public function testGetBadgeResponse(
+        Badge $badge,
+        string $provider = null,
+        \DateTime $cacheExpirationDate = null,
+    ): Response {
+        return $this->getBadgeResponse($badge, $provider, $cacheExpirationDate);
     }
 }

--- a/tests/Service/ApiServiceTest.php
+++ b/tests/Service/ApiServiceTest.php
@@ -43,7 +43,7 @@ final class ApiServiceTest extends AbstractApiTestCase
 
         $this->cache->get($cacheIdentifier, fn () => ['foo' => 'baz']);
 
-        self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo'));
+        self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo')->getMetadata());
         self::assertSame(0, $this->client->getRequestsCount());
 
         $this->cache->delete($cacheIdentifier);
@@ -56,7 +56,7 @@ final class ApiServiceTest extends AbstractApiTestCase
     {
         $this->mockResponses[] = new MockResponse(json_encode(['foo' => 'baz'], JSON_THROW_ON_ERROR));
 
-        self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo'));
+        self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo')->getMetadata());
         self::assertSame(1, $this->client->getRequestsCount());
         self::assertSame(['foo' => 'baz'], $this->cache->get($this->getCacheIdentifier(), fn () => null));
     }


### PR DESCRIPTION
This PR adds a basic application cache layer using Symfony's reverse proxy in combination with HTTP caching methods. Since TER API requests are already cached, the cache expiry date can be used and forwarded to the client.

Related: #136