### PR TITLE
[TASK] Update to deployer 7.0.0-rc.8

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy production
-          deployer-version: '7.0.0-rc.3'
+          deployer-version: '7.0.0-rc.8'
 
   dev:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -71,4 +71,4 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy dev --branch ${{ github.ref_name }}
-          deployer-version: '7.0.0-rc.3'
+          deployer-version: '7.0.0-rc.8'


### PR DESCRIPTION
This PR updates the currently used version of deployer to [7.0.0-rc.8](https://github.com/deployphp/deployer/releases/tag/v7.0.0-rc.8).