### PR TITLE
[BUGFIX] Skip concurrent workflow runs

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -8,8 +8,22 @@ on:
       - '**'
 
 jobs:
+  # Job: Check pre-conditions
+  check:
+    runs-on: ubuntu-20.04
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - id: check
+        uses: fkirc/skip-duplicate-actions@v4.0.0
+        with:
+          concurrent_skipping: 'same_content_newer'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   cgl:
     runs-on: ubuntu-20.04
+    needs: check
+    if: ${{ needs.check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,9 +8,23 @@ on:
       - '**'
 
 jobs:
+  # Job: Check pre-conditions
+  check:
+    runs-on: ubuntu-20.04
+    outputs:
+      should_skip: ${{ steps.check.outputs.should_skip }}
+    steps:
+      - id: check
+        uses: fkirc/skip-duplicate-actions@v4.0.0
+        with:
+          concurrent_skipping: 'same_content_newer'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
+
   # Job: Run unit tests
   tests:
     runs-on: ubuntu-20.04
+    needs: check
+    if: ${{ needs.check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR ensures that concurrent workflows are never run. This reduces the amount of workflows since we don't need to run a workflow both for push and pull_request events. If no PR is created, we must still make sure that a workflow is run.