### PR TITLE
[BUGFIX] Run auto-merge workflow only for dependabot actions

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   dependabot-auto-merge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The `auto-merge` workflow must not be run if any actor other than dependabot triggered the workflow. This is fixed now.