### PR TITLE
[BUGFIX] Avoid unnecessary workflow runs

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,6 +1,8 @@
 name: Dependabot auto-merge
 on:
   pull_request:
+    branches:
+      - 'dependabot/**'
 
 jobs:
   dependabot-auto-merge:

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -2,7 +2,8 @@ name: CGL
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,8 @@ name: Tests
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
This PR limits how workflows are run:

- [x] CGL and Tests workflows are run on push only in `main` or `develop`
- [x] Auto-merge workflow is run only on PR in `dependabot/*` branches