### PR TITLE
[TASK] Drop usage of `develop` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       day: friday
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -22,7 +21,6 @@ updates:
       day: friday
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -34,7 +32,6 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Badges for TYPO3 extensions
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/typo3-badges/branch/develop/graph/badge.svg?token=YIPIE5IZX3)](https://codecov.io/gh/eliashaeussler/typo3-badges)
+[![Coverage](https://codecov.io/gh/eliashaeussler/typo3-badges/branch/main/graph/badge.svg?token=YIPIE5IZX3)](https://codecov.io/gh/eliashaeussler/typo3-badges)
 [![Maintainability](https://api.codeclimate.com/v1/badges/47c15aa6c889330c5913/maintainability)](https://codeclimate.com/github/eliashaeussler/typo3-badges/maintainability)
 [![Uptime monitoring](https://betteruptime.com/status-badges/v1/monitor/bxsw.svg)](https://up.eliash.de/)
 [![Deploy](https://github.com/eliashaeussler/typo3-badges/actions/workflows/deploy.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-badges/actions/workflows/deploy.yaml)


### PR DESCRIPTION
With this PR, the repository is prepared to use the `main` branch as actual main branch instead of the `develop` branch which is likely to be dropped soon.