### PR TITLE
[FEATURE] Use random extension key on homepage's code examples

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,3 +1,6 @@
 services:
   # Disable logger to avoid showing errors during tests
   logger: '@Psr\Log\NullLogger'
+
+  App\Service\ApiService:
+    public: true

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -25,6 +25,7 @@ namespace App\Controller;
 
 use App\Badge\Provider\BadgeProviderFactory;
 use App\Badge\Provider\ShieldsBadgeProvider;
+use App\Service\ApiService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -42,6 +43,7 @@ final class HomepageController extends AbstractController
     public function __construct(
         private RouterInterface $router,
         private BadgeProviderFactory $badgeProviderFactory,
+        private ApiService $apiService,
     ) {
     }
 
@@ -53,6 +55,7 @@ final class HomepageController extends AbstractController
             'routes' => $this->getRoutes(),
             'providers' => $providers,
             'defaultProvider' => $providers[ShieldsBadgeProvider::getIdentifier()],
+            'randomExtensionKey' => $this->apiService->getRandomExtensionKey(),
         ]);
     }
 

--- a/templates/homepage/endpoints.html.twig
+++ b/templates/homepage/endpoints.html.twig
@@ -21,7 +21,7 @@
 
                 {% for provider in providers %}
                     {% if route.hasRequirement('extension') %}
-                        {% set routeParameters = {'extension': 'handlebars'} %}
+                        {% set routeParameters = {'extension': randomExtensionKey} %}
                     {% else %}
                         {% set routeParameters = {} %}
                     {% endif %}

--- a/templates/homepage/usage.html.twig
+++ b/templates/homepage/usage.html.twig
@@ -49,7 +49,7 @@
     {% endblock %}
     {% block item3_description %}
         <code class="inline border-b border-dashed border-gray-500 pb-0.5 text-sm">
-            {{ provider.generateUriForRoute(routes | keys | first, {'extension': 'handlebars'}) }}
+            {{ provider.generateUriForRoute(routes | keys | first, {'extension': randomExtensionKey}) }}
         </code>
         <br>
         <div class="inline-flex mt-4 text-xs text-gray-400" role="alert">
@@ -92,7 +92,7 @@
     {% endblock %}
     {% block item3_description %}
         <code class="inline border-b border-dashed border-gray-500 pb-0.5 text-sm">
-            {{ provider.generateUriForRoute(routes | keys | first, {'extension': 'handlebars'}) }}
+            {{ provider.generateUriForRoute(routes | keys | first, {'extension': randomExtensionKey}) }}
         </code>
         <br>
         <div class="inline-flex mt-4 text-xs text-gray-400" role="alert">

--- a/tests/AbstractApiTestCase.php
+++ b/tests/AbstractApiTestCase.php
@@ -48,8 +48,11 @@ abstract class AbstractApiTestCase extends KernelTestCase
         $this->apiService = new ApiService($this->getMockClient(), $this->cache);
     }
 
-    protected function getCacheIdentifier(): string
+    /**
+     * @param array<string, string> $options
+     */
+    protected function getCacheIdentifier(string $key, array $options = []): string
     {
-        return hash('sha512', 'typo3_api.extension_metadata_{"apiPath":"\/api\/v1\/extension\/foo"}');
+        return hash('sha512', $key.'_'.json_encode($options));
     }
 }

--- a/tests/MockClientTrait.php
+++ b/tests/MockClientTrait.php
@@ -23,33 +23,38 @@ declare(strict_types=1);
 
 namespace App\Tests;
 
-use App\Service\ApiService;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 
 /**
- * AbstractApiTestCase.
+ * MockClientTrait.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-abstract class AbstractApiTestCase extends KernelTestCase
+trait MockClientTrait
 {
-    use MockClientTrait;
+    protected ?MockHttpClient $mockClient = null;
 
-    protected CacheInterface $cache;
-    protected ApiService $apiService;
+    /**
+     * @var array<MockResponse>
+     */
+    protected array $mockResponses = [];
 
-    protected function setUp(): void
+    protected function getMockClient(): MockHttpClient
     {
-        self::bootKernel();
+        if (null === $this->mockClient) {
+            $this->mockClient = new MockHttpClient($this->getMockResponses());
+        }
 
-        $this->cache = self::getContainer()->get(CacheInterface::class);
-        $this->apiService = new ApiService($this->getMockClient(), $this->cache);
+        return $this->mockClient;
     }
 
-    protected function getCacheIdentifier(): string
+    /**
+     * @return \Generator<MockResponse>
+     */
+    protected function getMockResponses(): \Generator
     {
-        return hash('sha512', 'typo3_api.extension_metadata_{"apiPath":"\/api\/v1\/extension\/foo"}');
+        yield from $this->mockResponses;
     }
 }

--- a/tests/Service/ApiServiceTest.php
+++ b/tests/Service/ApiServiceTest.php
@@ -44,7 +44,7 @@ final class ApiServiceTest extends AbstractApiTestCase
         $this->cache->get($cacheIdentifier, fn () => ['foo' => 'baz']);
 
         self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo')->getMetadata());
-        self::assertSame(0, $this->client->getRequestsCount());
+        self::assertSame(0, $this->mockClient?->getRequestsCount());
 
         $this->cache->delete($cacheIdentifier);
     }
@@ -57,7 +57,7 @@ final class ApiServiceTest extends AbstractApiTestCase
         $this->mockResponses[] = new MockResponse(json_encode(['foo' => 'baz'], JSON_THROW_ON_ERROR));
 
         self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo')->getMetadata());
-        self::assertSame(1, $this->client->getRequestsCount());
+        self::assertSame(1, $this->mockClient?->getRequestsCount());
         self::assertSame(['foo' => 'baz'], $this->cache->get($this->getCacheIdentifier(), fn () => null));
     }
 }

--- a/tests/Service/ApiServiceTest.php
+++ b/tests/Service/ApiServiceTest.php
@@ -39,7 +39,9 @@ final class ApiServiceTest extends AbstractApiTestCase
      */
     public function getExtensionMetadataReturnsMetadataFromCache(): void
     {
-        $cacheIdentifier = $this->getCacheIdentifier();
+        $cacheIdentifier = $this->getCacheIdentifier('typo3_api.extension_metadata', [
+            'apiPath' => '/api/v1/extension/foo',
+        ]);
 
         $this->cache->get($cacheIdentifier, fn () => ['foo' => 'baz']);
 
@@ -56,8 +58,69 @@ final class ApiServiceTest extends AbstractApiTestCase
     {
         $this->mockResponses[] = new MockResponse(json_encode(['foo' => 'baz'], JSON_THROW_ON_ERROR));
 
+        $cacheIdentifier = $this->getCacheIdentifier('typo3_api.extension_metadata', [
+            'apiPath' => '/api/v1/extension/foo',
+        ]);
+
         self::assertSame(['foo' => 'baz'], $this->apiService->getExtensionMetadata('foo')->getMetadata());
         self::assertSame(1, $this->mockClient?->getRequestsCount());
-        self::assertSame(['foo' => 'baz'], $this->cache->get($this->getCacheIdentifier(), fn () => null));
+        self::assertSame(['foo' => 'baz'], $this->cache->get($cacheIdentifier, fn () => null));
+    }
+
+    /**
+     * @test
+     */
+    public function getRandomExtensionKeyReturnsExtensionKeyFromCache(): void
+    {
+        $cacheIdentifier = $this->getCacheIdentifier('typo3_api.random_extensions', [
+            'apiPath' => '/api/v1/extension',
+        ]);
+
+        $this->cache->get($cacheIdentifier, fn () => [
+            'extensions' => [
+                [
+                    'key' => 'foo',
+                ],
+            ],
+        ]);
+
+        self::assertSame('foo', $this->apiService->getRandomExtensionKey());
+        self::assertSame(0, $this->mockClient?->getRequestsCount());
+
+        $this->cache->delete($cacheIdentifier);
+    }
+
+    /**
+     * @test
+     */
+    public function getRandomExtensionKeyReturnsExtensionKeyFromApiAndStoresResponseInCache(): void
+    {
+        $json = [
+            'extensions' => [
+                [
+                    'key' => 'foo',
+                ],
+            ],
+        ];
+
+        $this->mockResponses[] = new MockResponse(json_encode($json, JSON_THROW_ON_ERROR));
+
+        $cacheIdentifier = $this->getCacheIdentifier('typo3_api.random_extensions', [
+            'apiPath' => '/api/v1/extension',
+        ]);
+
+        self::assertSame('foo', $this->apiService->getRandomExtensionKey());
+        self::assertSame(1, $this->mockClient?->getRequestsCount());
+        self::assertSame($json, $this->cache->get($cacheIdentifier, fn () => null));
+    }
+
+    /**
+     * @test
+     */
+    public function getRandomExtensionKeyReturnsFallbackIfRandomExtensionKeysCannotBeFetchedFromApi(): void
+    {
+        $this->mockResponses[] = new MockResponse('{}');
+
+        self::assertSame('handlebars', $this->apiService->getRandomExtensionKey());
     }
 }


### PR DESCRIPTION
With this PR, random extension keys are used within code examples on the homepage. For this, a random extension key is fetched by using the TER REST API endpoint `/extension`. In case fetching random extension keys does not work as expected, the fallback extension key `handlebars` is used.

Resolves: #156