### PR TITLE
[BUGFIX] Make homepage cacheable

### DIFF
--- a/src/Controller/AbstractBadgeController.php
+++ b/src/Controller/AbstractBadgeController.php
@@ -37,6 +37,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 abstract class AbstractBadgeController
 {
+    use CacheableResponseTrait;
+
     protected BadgeProviderFactory $badgeProviderFactory;
 
     /**
@@ -61,9 +63,7 @@ abstract class AbstractBadgeController
         $response = $providerClass->createResponse($badge);
 
         if (null !== $cacheExpirationDate) {
-            $response->setPublic();
-            $response->setExpires($cacheExpirationDate);
-            $response->headers->addCacheControlDirective('must-revalidate', true);
+            $this->markResponseAsCacheable($response, $cacheExpirationDate);
         }
 
         return $response;

--- a/src/Controller/CacheableResponseTrait.php
+++ b/src/Controller/CacheableResponseTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * CacheableResponseTrait.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+trait CacheableResponseTrait
+{
+    private function markResponseAsCacheable(Response $response, \DateTime $cacheExpirationDate): void
+    {
+        $response->setPublic();
+        $response->setExpires($cacheExpirationDate);
+        $response->headers->addCacheControlDirective('must-revalidate');
+    }
+}

--- a/tests/Controller/HomepageControllerTest.php
+++ b/tests/Controller/HomepageControllerTest.php
@@ -57,7 +57,13 @@ final class HomepageControllerTest extends WebTestCase
      */
     public function controllerReturnsHomepage(): void
     {
-        $this->mockResponses[] = new MockResponse(json_encode(['foo' => 'baz'], JSON_THROW_ON_ERROR));
+        $this->mockResponses[] = new MockResponse(json_encode([
+            'extensions' => [
+                [
+                    'key' => 'foo',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
 
         $crawler = $this->client->request('GET', '/');
         $allRoutes = self::getContainer()->get('router')->getRouteCollection()->all();

--- a/tests/Service/ApiServiceTest.php
+++ b/tests/Service/ApiServiceTest.php
@@ -70,7 +70,7 @@ final class ApiServiceTest extends AbstractApiTestCase
     /**
      * @test
      */
-    public function getRandomExtensionKeyReturnsExtensionKeyFromCache(): void
+    public function getRandomExtensionMetadataReturnsExtensionMetadataFromCache(): void
     {
         $cacheIdentifier = $this->getCacheIdentifier('typo3_api.random_extensions', [
             'apiPath' => '/api/v1/extension',
@@ -84,7 +84,7 @@ final class ApiServiceTest extends AbstractApiTestCase
             ],
         ]);
 
-        self::assertSame('foo', $this->apiService->getRandomExtensionKey());
+        self::assertSame(['key' => 'foo'], $this->apiService->getRandomExtensionMetadata()->getMetadata());
         self::assertSame(0, $this->mockClient?->getRequestsCount());
 
         $this->cache->delete($cacheIdentifier);
@@ -93,7 +93,7 @@ final class ApiServiceTest extends AbstractApiTestCase
     /**
      * @test
      */
-    public function getRandomExtensionKeyReturnsExtensionKeyFromApiAndStoresResponseInCache(): void
+    public function getRandomExtensionMetadataReturnsExtensionMetadataFromApiAndStoresResponseInCache(): void
     {
         $json = [
             'extensions' => [
@@ -109,7 +109,7 @@ final class ApiServiceTest extends AbstractApiTestCase
             'apiPath' => '/api/v1/extension',
         ]);
 
-        self::assertSame('foo', $this->apiService->getRandomExtensionKey());
+        self::assertSame(['key' => 'foo'], $this->apiService->getRandomExtensionMetadata()->getMetadata());
         self::assertSame(1, $this->mockClient?->getRequestsCount());
         self::assertSame($json, $this->cache->get($cacheIdentifier, fn () => null));
     }
@@ -117,10 +117,10 @@ final class ApiServiceTest extends AbstractApiTestCase
     /**
      * @test
      */
-    public function getRandomExtensionKeyReturnsFallbackIfRandomExtensionKeysCannotBeFetchedFromApi(): void
+    public function getRandomExtensionMetadataReturnsFallbackIfRandomExtensionsCannotBeFetchedFromApi(): void
     {
         $this->mockResponses[] = new MockResponse('{}');
 
-        self::assertSame('handlebars', $this->apiService->getRandomExtensionKey());
+        self::assertSame(['key' => 'handlebars'], $this->apiService->getRandomExtensionMetadata()->getMetadata());
     }
 }


### PR DESCRIPTION
Since #355, when visiting the homepage, random extension metadata is fetched from TER REST API and being cached. In order to align responses with the badge route responses, the homepage is now also properly cached using Symfony's HTTP cache.