### PR TITLE
[BUGFIX] Provide cache warmer for random extension metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
 		],
 		"auto-scripts": {
 			"assets:install %PUBLIC_DIR%": "symfony-cmd",
-			"cache:clear": "symfony-cmd"
+			"cache:clear --no-warmup": "symfony-cmd"
 		},
 		"lint": "php-cs-fixer fix",
 		"sca": "phpstan analyse -c phpstan.neon",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,3 +38,6 @@ services:
     App\Badge\Provider\BadgeProviderFactory:
         arguments:
             $providers: !tagged_locator { tag: badge.provider, index_by: 'key', default_index_method: 'getIdentifier' }
+
+    App\Cache\RandomExtensionMetadataCacheWarmer:
+        tags: ['kernel.cache_warmer']

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -4,3 +4,5 @@ services:
 
   App\Service\ApiService:
     public: true
+
+  App\Cache\RandomExtensionMetadataCacheWarmer: ~

--- a/src/Cache/RandomExtensionMetadataCacheWarmer.php
+++ b/src/Cache/RandomExtensionMetadataCacheWarmer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Cache;
+
+use App\Service\ApiService;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * RandomExtensionMetadataCacheWarmer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ * @codeCoverageIgnore
+ */
+final class RandomExtensionMetadataCacheWarmer implements CacheWarmerInterface
+{
+    public function __construct(
+        private ApiService $apiService,
+    ) {
+    }
+
+    public function warmUp(string $cacheDir): array
+    {
+        $this->apiService->getRandomExtensionMetadata();
+
+        return [];
+    }
+
+    public function isOptional(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Since fetching random extension metadata from TER is a long-performing process that is triggered on cold caches, we must make sure that this cache gets warmed before anyone accesses it. For this, an appropriate cache warmer has been added.