### PR TITLE
[FEATURE] Introduce GitHub workflow to validate OpenAPI definition

### DIFF
--- a/.github/workflows/schema.yaml
+++ b/.github/workflows/schema.yaml
@@ -1,0 +1,21 @@
+name: API schema
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Validate OpenAPI definition
+        uses: char0n/swagger-editor-validate@v1
+        with:
+          definition-file: spec/typo3-badges.oas3.yaml

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Deploy](https://github.com/eliashaeussler/typo3-badges/actions/workflows/deploy.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-badges/actions/workflows/deploy.yaml)
 [![Tests](https://github.com/eliashaeussler/typo3-badges/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-badges/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/typo3-badges/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-badges/actions/workflows/cgl.yaml)
+[![API schema](https://github.com/eliashaeussler/typo3-badges/actions/workflows/schema.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-badges/actions/workflows/schema.yaml)
 [![Latest version](https://img.shields.io/github/v/release/eliashaeussler/typo3-badges)](https://github.com/eliashaeussler/typo3-badges/releases/latest)
 [![License](https://img.shields.io/github/license/eliashaeussler/typo3-badges)](LICENSE)
 [![TYPO3 – inspiring people to share!](https://shields.io/endpoint?url=https://typo3-badges.dev/badge/typo3)](https://typo3-badges.dev)


### PR DESCRIPTION
This PR adds a new GitHub workflow that validates the OpenAPI definition with the help of https://github.com/char0n/swagger-editor-validate GitHub Action.