### PR TITLE
[TASK] Switch to fastify/github-action-merge-dependabot

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -2,13 +2,16 @@ name: Dependabot auto-merge
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   dependabot-auto-merge:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: fastify/github-action-merge-dependabot@v3.2.0
         with:
           target: minor
-          github-token: ${{ secrets.MERGE_TOKEN }}
+          approve-only: true


### PR DESCRIPTION
This PR switches the action used for Dependabot auto-merges to `fastify/github-action-merge-dependabot` since it performs better.