### PR TITLE
[TASK] Run Dependabot updates daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
   - package-ecosystem: composer
     directory: '/'
     schedule:
-      interval: weekly
-      day: friday
+      interval: daily
     commit-message:
       prefix: '[TASK]'
     labels:
@@ -17,8 +16,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
-      day: friday
+      interval: daily
     commit-message:
       prefix: '[TASK]'
     labels:


### PR DESCRIPTION
With this PR, Dependabot updates are now run daily instead of only on Fridays.