### PR TITLE
[FEATURE] Introduce endpoint for TYPO3 versions badge

### DIFF
--- a/spec/typo3-badges.oas3.yaml
+++ b/spec/typo3-badges.oas3.yaml
@@ -114,6 +114,31 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+  /badge/{extension}/typo3/{provider}:
+    get:
+      description: TYPO3 versions badge
+      summary: >-
+        Gets badge data for supported TYPO3 versions of given TYPO3 extension using the
+        default badge provider.
+      operationId: getTypo3Badge
+      parameters:
+        - $ref: '#/components/parameters/Extension'
+        - $ref: '#/components/parameters/Provider'
+      tags:
+        - Badge
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/BadgenResponse'
+                  - $ref: '#/components/schemas/ShieldsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /badge/{extension}/version/{provider}:
     get:
       description: Version badge

--- a/src/Controller/Typo3BadgeController.php
+++ b/src/Controller/Typo3BadgeController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Controller;
+
+use App\Entity\Badge;
+use App\Service\ApiService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * Typo3BadgeController.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Route(
+    path: '/badge/{extension}/typo3/{provider?}',
+    name: 'badge.typo3',
+    requirements: ['extension' => '[a-z0-9_]+'],
+    options: ['description' => 'Get JSON data for supported TYPO3 versions.'],
+    methods: ['GET'],
+)]
+final class Typo3BadgeController extends AbstractBadgeController
+{
+    public function __construct(
+        private readonly ApiService $apiService,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $extension, string $provider = null): Response
+    {
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $typo3Versions = $extensionMetadata[0]['current_version']['typo3_versions']
+            ?? throw new BadRequestHttpException('Invalid API response.');
+
+        return $this->getBadgeResponse(
+            Badge::forTypo3Versions($typo3Versions),
+            $provider,
+            $extensionMetadata->getExpiryDate(),
+        );
+    }
+}

--- a/src/Entity/Badge.php
+++ b/src/Entity/Badge.php
@@ -37,6 +37,7 @@ final class Badge
         'extension' => 'orange',
         'version' => 'orange',
         'downloads' => 'blue',
+        'typo3' => 'orange',
         'error' => 'red',
         'stability_stable' => 'green',
         'stability_beta' => 'yellow',
@@ -79,6 +80,30 @@ final class Badge
             label: 'typo3',
             message: sprintf('%s downloads', strtolower(NumberFormatter::format($downloads))),
             color: self::COLOR_MAP['downloads'],
+        );
+    }
+
+    /**
+     * @param list<int> $typo3Versions
+     */
+    public static function forTypo3Versions(array $typo3Versions): self
+    {
+        if ([] === $typo3Versions) {
+            return self::forError();
+        }
+
+        sort($typo3Versions);
+
+        $lastValue = array_pop($typo3Versions);
+        $message = implode(' & ', array_filter([
+            implode(', ', $typo3Versions) ?: null,
+            $lastValue,
+        ]));
+
+        return new self(
+            label: 'typo3',
+            message: $message,
+            color: self::COLOR_MAP['typo3'],
         );
     }
 

--- a/tests/Controller/DownloadsBadgeControllerTest.php
+++ b/tests/Controller/DownloadsBadgeControllerTest.php
@@ -58,7 +58,7 @@ final class DownloadsBadgeControllerTest extends AbstractApiTestCase
         $this->expectException(BadRequestHttpException::class);
         $this->expectErrorMessage('Invalid API response.');
 
-        $this->subject->__invoke(new Request(), 'foo');
+        ($this->subject)(new Request(), 'foo');
     }
 
     /**
@@ -83,7 +83,7 @@ final class DownloadsBadgeControllerTest extends AbstractApiTestCase
 
         self::assertSame(
             $expected->getContent(),
-            $this->subject->__invoke(new Request(), 'foo')->getContent()
+            ($this->subject)(new Request(), 'foo')->getContent()
         );
     }
 }

--- a/tests/Controller/ExtensionBadgeControllerTest.php
+++ b/tests/Controller/ExtensionBadgeControllerTest.php
@@ -58,7 +58,7 @@ final class ExtensionBadgeControllerTest extends AbstractApiTestCase
         $this->expectException(BadRequestHttpException::class);
         $this->expectErrorMessage('Invalid API response.');
 
-        $this->subject->__invoke(new Request(), 'foo');
+        ($this->subject)(new Request(), 'foo');
     }
 
     /**
@@ -83,7 +83,7 @@ final class ExtensionBadgeControllerTest extends AbstractApiTestCase
 
         self::assertSame(
             $expected->getContent(),
-            $this->subject->__invoke(new Request(), 'foo')->getContent()
+            ($this->subject)(new Request(), 'foo')->getContent()
         );
     }
 }

--- a/tests/Controller/StabilityBadgeControllerTest.php
+++ b/tests/Controller/StabilityBadgeControllerTest.php
@@ -58,7 +58,7 @@ final class StabilityBadgeControllerTest extends AbstractApiTestCase
         $this->expectException(BadRequestHttpException::class);
         $this->expectErrorMessage('Invalid API response.');
 
-        $this->subject->__invoke(new Request(), 'foo');
+        ($this->subject)(new Request(), 'foo');
     }
 
     /**
@@ -87,7 +87,7 @@ final class StabilityBadgeControllerTest extends AbstractApiTestCase
 
         self::assertSame(
             $expected->getContent(),
-            $this->subject->__invoke(new Request(), 'foo')->getContent()
+            ($this->subject)(new Request(), 'foo')->getContent()
         );
     }
 

--- a/tests/Controller/Typo3BadgeControllerTest.php
+++ b/tests/Controller/Typo3BadgeControllerTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace App\Tests\Controller;
 
 use App\Badge\Provider\BadgeProviderFactory;
-use App\Controller\VersionBadgeController;
+use App\Controller\Typo3BadgeController;
 use App\Tests\AbstractApiTestCase;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,19 +32,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
- * VersionBadgeControllerTest.
+ * Typo3BadgeControllerTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class VersionBadgeControllerTest extends AbstractApiTestCase
+final class Typo3BadgeControllerTest extends AbstractApiTestCase
 {
-    private VersionBadgeController $subject;
+    private Typo3BadgeController $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->subject = new VersionBadgeController($this->apiService);
+        $this->subject = new Typo3BadgeController($this->apiService);
         $this->subject->setBadgeProviderFactory(self::getContainer()->get(BadgeProviderFactory::class));
     }
 
@@ -69,7 +69,7 @@ final class VersionBadgeControllerTest extends AbstractApiTestCase
         $this->mockResponses[] = new MockResponse(json_encode([
             [
                 'current_version' => [
-                    'number' => '1.0.0',
+                    'typo3_versions' => [10, 11],
                 ],
             ],
         ], JSON_THROW_ON_ERROR));
@@ -77,7 +77,7 @@ final class VersionBadgeControllerTest extends AbstractApiTestCase
         $expected = new JsonResponse([
             'schemaVersion' => 1,
             'label' => 'typo3',
-            'message' => '1.0.0',
+            'message' => '10 & 11',
             'color' => 'orange',
             'isError' => false,
             'namedLogo' => 'typo3',

--- a/tests/Entity/BadgeTest.php
+++ b/tests/Entity/BadgeTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Badge;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -77,6 +78,35 @@ final class BadgeTest extends TestCase
         );
 
         self::assertEquals($expected, Badge::forDownloads(845760473));
+    }
+
+    /**
+     * @test
+     */
+    public function forTypo3VersionsReturnsErrorBadgeForEmptyTypo3VersionList(): void
+    {
+        $expected = Badge::forError();
+
+        self::assertEquals($expected, Badge::forTypo3Versions([]));
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider forTypo3VersionsReturnsBadgeForTypo3VersionsDataProvider
+     *
+     * @param list<int> $typo3Versions
+     */
+    public function forTypo3VersionsReturnsBadgeForTypo3Versions(array $typo3Versions, string $expected): void
+    {
+        $expected = new Badge(
+            label: 'typo3',
+            message: $expected,
+            color: 'orange',
+            isError: false,
+        );
+
+        self::assertEquals($expected, Badge::forTypo3Versions($typo3Versions));
     }
 
     /**
@@ -170,7 +200,7 @@ final class BadgeTest extends TestCase
     /**
      * @return \Generator<string, array{string, string}>
      */
-    public function forStabilityReturnsBadgeForStabilityDataProvider(): \Generator
+    public function forStabilityReturnsBadgeForStabilityDataProvider(): Generator
     {
         yield 'stable' => ['stable', 'green'];
         yield 'beta' => ['beta', 'yellow'];
@@ -179,5 +209,15 @@ final class BadgeTest extends TestCase
         yield 'test' => ['test', 'lightgrey'];
         yield 'obsolete' => ['obsolete', 'lightgrey'];
         yield 'excludeFromUpdates' => ['excludeFromUpdates', 'lightgrey'];
+    }
+
+    /**
+     * @return Generator<string, array{list<int>, string}>
+     */
+    public function forTypo3VersionsReturnsBadgeForTypo3VersionsDataProvider(): Generator
+    {
+        yield 'one version' => [[11], '11'];
+        yield 'two versions' => [[10, 11], '10 & 11'];
+        yield 'three versions' => [[9, 10, 11], '9, 10 & 11'];
     }
 }


### PR DESCRIPTION
This PR introduces a new endpoint:

**`GET /badge/{extension}/typo3/{provider}`**

It can be used to generated badges indicating the currently supported TYPO3 versions of the given extension.