### PR TITLE
[FEATURE] Properly name labels in generated badges

### DIFF
--- a/src/Entity/Badge.php
+++ b/src/Entity/Badge.php
@@ -59,7 +59,7 @@ final class Badge
     public static function forExtension(string $extension): self
     {
         return new self(
-            label: 'typo3',
+            label: 'extension',
             message: $extension,
             color: self::COLOR_MAP['extension'],
         );
@@ -68,7 +68,7 @@ final class Badge
     public static function forVersion(string $version): self
     {
         return new self(
-            label: 'typo3',
+            label: 'version',
             message: $version,
             color: self::COLOR_MAP['version'],
         );
@@ -77,8 +77,8 @@ final class Badge
     public static function forDownloads(int $downloads): self
     {
         return new self(
-            label: 'typo3',
-            message: sprintf('%s downloads', strtolower(NumberFormatter::format($downloads))),
+            label: 'downloads',
+            message: strtolower(NumberFormatter::format($downloads)),
             color: self::COLOR_MAP['downloads'],
         );
     }
@@ -110,7 +110,7 @@ final class Badge
     public static function forStability(string $stability): self
     {
         return new self(
-            label: 'typo3',
+            label: 'stability',
             message: $stability,
             color: self::COLOR_MAP['stability_'.$stability] ?? 'orange',
         );

--- a/tests/Controller/DownloadsBadgeControllerTest.php
+++ b/tests/Controller/DownloadsBadgeControllerTest.php
@@ -74,8 +74,8 @@ final class DownloadsBadgeControllerTest extends AbstractApiTestCase
 
         $expected = new JsonResponse([
             'schemaVersion' => 1,
-            'label' => 'typo3',
-            'message' => '123 downloads',
+            'label' => 'downloads',
+            'message' => '123',
             'color' => 'blue',
             'isError' => false,
             'namedLogo' => 'typo3',

--- a/tests/Controller/ExtensionBadgeControllerTest.php
+++ b/tests/Controller/ExtensionBadgeControllerTest.php
@@ -74,7 +74,7 @@ final class ExtensionBadgeControllerTest extends AbstractApiTestCase
 
         $expected = new JsonResponse([
             'schemaVersion' => 1,
-            'label' => 'typo3',
+            'label' => 'extension',
             'message' => 'foo',
             'color' => 'orange',
             'isError' => false,

--- a/tests/Controller/StabilityBadgeControllerTest.php
+++ b/tests/Controller/StabilityBadgeControllerTest.php
@@ -78,7 +78,7 @@ final class StabilityBadgeControllerTest extends AbstractApiTestCase
 
         $expected = new JsonResponse([
             'schemaVersion' => 1,
-            'label' => 'typo3',
+            'label' => 'stability',
             'message' => $state,
             'color' => $expectedColor,
             'isError' => false,

--- a/tests/Controller/VersionBadgeControllerTest.php
+++ b/tests/Controller/VersionBadgeControllerTest.php
@@ -76,7 +76,7 @@ final class VersionBadgeControllerTest extends AbstractApiTestCase
 
         $expected = new JsonResponse([
             'schemaVersion' => 1,
-            'label' => 'typo3',
+            'label' => 'version',
             'message' => '1.0.0',
             'color' => 'orange',
             'isError' => false,

--- a/tests/Entity/BadgeTest.php
+++ b/tests/Entity/BadgeTest.php
@@ -41,7 +41,7 @@ final class BadgeTest extends TestCase
     public function forExtensionReturnsBadgeForExtension(): void
     {
         $expected = new Badge(
-            label: 'typo3',
+            label: 'extension',
             message: 'foo',
             color: 'orange',
             isError: false,
@@ -56,7 +56,7 @@ final class BadgeTest extends TestCase
     public function forVersionReturnsBadgeForVersion(): void
     {
         $expected = new Badge(
-            label: 'typo3',
+            label: 'version',
             message: '1.0.0',
             color: 'orange',
             isError: false,
@@ -71,8 +71,8 @@ final class BadgeTest extends TestCase
     public function forDownloadsReturnsBadgeForDownloads(): void
     {
         $expected = new Badge(
-            label: 'typo3',
-            message: '845.8m downloads',
+            label: 'downloads',
+            message: '845.8m',
             color: 'blue',
             isError: false,
         );
@@ -117,7 +117,7 @@ final class BadgeTest extends TestCase
     public function forStabilityReturnsBadgeForStability(string $stability, string $expectedColor): void
     {
         $expected = new Badge(
-            label: 'typo3',
+            label: 'stability',
             message: $stability,
             color: $expectedColor,
             isError: false,


### PR DESCRIPTION
Currently, all badges are labelled `typo3`. This does not look very nice when many different badges are used together. With this change, the labels are now streamlined to the appropriate badge message. One can still override the labels by passing the appropriate query parameters to the provider url (shields.io / badgen).