### PR TITLE
[TASK] Use ramsey/composer-install action in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -28,7 +28,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer install --no-progress
+        uses: ramsey/composer-install@v2
       - name: Install node modules
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,6 +21,10 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2, composer-require-checker, composer-unused:0.7
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
 
       # Validation
       - name: Validate composer.json

--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -23,7 +23,7 @@ jobs:
 
       # Normalize composer.json
       - name: Install Composer dependencies
-        run: composer install --no-progress
+        uses: ramsey/composer-install@v2
       - name: Normalize composer.json
         run: composer normalize --no-check-lock
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,9 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer install --no-dev --no-progress --optimize-autoloader
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --no-dev --optimize-autoloader
       - name: Install node modules
         run: yarn --frozen-lockfile
 
@@ -71,7 +73,9 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer install --no-dev --no-progress --optimize-autoloader
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --no-dev --optimize-autoloader
       - name: Install node modules
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,10 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
 
       # Install dependencies
       - name: Install Composer dependencies
@@ -70,6 +74,10 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
 
       # Install dependencies
       - name: Install Composer dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,22 +24,9 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
-      # Define Composer cache
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Define Composer cache
-        uses: actions/cache@v3.0.11
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: tests-php-8.0
-          restore-keys: |
-            tests-php-
-
       # Install dependencies
-      - name: Install Composer and dependencies
-        run: composer install --no-progress
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
       - name: Install node modules
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,6 +23,10 @@ jobs:
           php-version: 8.1
           tools: composer:v2
           coverage: xdebug
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
 
       # Install dependencies
       - name: Install Composer dependencies


### PR DESCRIPTION
With this PR, the `ramsey/composer-install` action is now used for `composer install` in CI. Additionally, the `actions/setup-node` action is used to set up Node with yarn caching enabled.