### PR TITLE
[BUGFIX] Replace deprecated job outputs in GitHub workflows

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -30,8 +30,7 @@ jobs:
       # Update PR
       - name: Get last commit message
         id: last-commit-message
-        run: |
-          echo "::set-output name=msg::$(git log -1 --pretty=%s)"
+        run: echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{ steps.last-commit-message.outputs.msg }}


### PR DESCRIPTION
With GitHub [deprecating the `set-output` commands in GitHub workflows](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the new `$GITHUB_OUTPUT` variable needs to be used instead.