### PR TITLE
[BUGFIX] Upgrade to stable Deployer version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,7 +55,7 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy production
-          deployer-version: '7.0.0-rc.8'
+          deployer-version: '7.0.2'
 
   dev:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -103,4 +103,4 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy dev
-          deployer-version: '7.0.0-rc.8'
+          deployer-version: '7.0.2'


### PR DESCRIPTION
Deployer v7 was released some time ago, but the version was not increased in the deploy workflow. We now use the stable version v7.0.2.