### PR TITLE
[BUGFIX] Switch back to Deployer 7.3.0

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy production
-          deployer-version: '7.3.1'
+          deployer-version: '7.3.0'
 
   dev:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -105,4 +105,4 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
           known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           dep: deploy dev
-          deployer-version: '7.3.1'
+          deployer-version: '7.3.0'


### PR DESCRIPTION
Due to deployphp/deployer#3562, Deployer 7.3.1 cannot yet used for GitHub Actions. Thus, we switch back to 7.3.0.