### PR TITLE
[FEATURE] Let badge providers handle color values individually

### DIFF
--- a/src/Badge/Provider/BadgeProviderFactory.php
+++ b/src/Badge/Provider/BadgeProviderFactory.php
@@ -53,7 +53,6 @@ final readonly class BadgeProviderFactory
         /** @var class-string<BadgeProvider> $service */
         foreach ($this->providers->getProvidedServices() as $serviceId => $service) {
             if ($service::getIdentifier() === $name) {
-                /* @noinspection PhpUnhandledExceptionInspection */
                 return $this->providers->get($serviceId);
             }
         }
@@ -69,7 +68,6 @@ final readonly class BadgeProviderFactory
         $providers = [];
 
         foreach (array_keys($this->providers->getProvidedServices()) as $serviceId) {
-            /* @noinspection PhpUnhandledExceptionInspection */
             $provider = $this->providers->get($serviceId);
             assert($provider instanceof BadgeProvider);
 

--- a/src/Badge/Provider/BadgenBadgeProvider.php
+++ b/src/Badge/Provider/BadgenBadgeProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Badge\Provider;
 
 use App\Entity\Badge;
+use App\Enums\Color;
 use Nyholm\Psr7\Uri;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -64,9 +65,9 @@ final class BadgenBadgeProvider implements BadgeProvider
     public function createResponse(Badge $badge): Response
     {
         return new JsonResponse([
-            'subject' => '' !== $badge->getLabel() ? $badge->getLabel() : 'typo3',
-            'status' => '' !== $badge->getMessage() ? $badge->getMessage() : 'inspiring people to share',
-            'color' => '' !== $badge->getColor() ? $badge->getColor() : 'orange',
+            'subject' => $badge->getLabel(),
+            'status' => $badge->getMessage(),
+            'color' => $this->getColorValue($badge->getColor()),
         ]);
     }
 
@@ -97,5 +98,17 @@ final class BadgenBadgeProvider implements BadgeProvider
     public function getProviderUrl(): string
     {
         return 'https://badgen.net';
+    }
+
+    private function getColorValue(Color $color): string
+    {
+        return match ($color) {
+            Color::Blue => 'blue',
+            Color::Gray => 'grey',
+            Color::Green => 'green',
+            Color::Orange => 'orange',
+            Color::Red => 'red',
+            Color::Yellow => 'yellow',
+        };
     }
 }

--- a/src/Badge/Provider/ShieldsBadgeProvider.php
+++ b/src/Badge/Provider/ShieldsBadgeProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Badge\Provider;
 
 use App\Entity\Badge;
+use App\Enums\Color;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -64,9 +65,9 @@ final class ShieldsBadgeProvider implements BadgeProvider
     {
         return new JsonResponse([
             'schemaVersion' => 1,
-            'label' => '' !== $badge->getLabel() ? $badge->getLabel() : 'typo3',
-            'message' => '' !== $badge->getMessage() ? $badge->getMessage() : 'inspiring people to share',
-            'color' => '' !== $badge->getColor() ? $badge->getColor() : 'orange',
+            'label' => $badge->getLabel(),
+            'message' => $badge->getMessage(),
+            'color' => $this->getColorValue($badge->getColor()),
             'isError' => $badge->isError(),
             'namedLogo' => 'typo3',
         ]);
@@ -98,5 +99,17 @@ final class ShieldsBadgeProvider implements BadgeProvider
     public function getProviderUrl(): string
     {
         return 'https://shields.io';
+    }
+
+    private function getColorValue(Color $color): string
+    {
+        return match ($color) {
+            Color::Blue => 'blue',
+            Color::Gray => 'lightgrey',
+            Color::Green => 'green',
+            Color::Orange => 'orange',
+            Color::Red => 'red',
+            Color::Yellow => 'yellow',
+        };
     }
 }

--- a/src/Controller/DefaultBadgeController.php
+++ b/src/Controller/DefaultBadgeController.php
@@ -48,6 +48,6 @@ final class DefaultBadgeController extends AbstractBadgeController
 {
     public function __invoke(Request $request, string $provider = null): Response
     {
-        return $this->getBadgeResponse(new Badge(), $provider);
+        return $this->getBadgeResponse(Badge::static(), $provider);
     }
 }

--- a/src/Entity/Badge.php
+++ b/src/Entity/Badge.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Enums\Color;
 use App\Value\NumberFormatter;
 
 use function implode;
@@ -36,59 +37,78 @@ use function implode;
 final readonly class Badge
 {
     private const COLOR_MAP = [
-        'extension' => 'orange',
-        'version' => 'orange',
-        'downloads' => 'blue',
-        'typo3' => 'orange',
-        'error' => 'red',
-        'stability_stable' => 'green',
-        'stability_beta' => 'yellow',
-        'stability_alpha' => 'red',
-        'stability_experimental' => 'red',
-        'stability_test' => 'lightgrey',
-        'stability_obsolete' => 'lightgrey',
-        'stability_excludeFromUpdates' => 'lightgrey',
-        'verified' => 'green',
-        'not_verified' => 'lightgrey',
+        'extension' => Color::Orange,
+        'version' => Color::Orange,
+        'downloads' => Color::Blue,
+        'typo3' => Color::Orange,
+        'error' => Color::Red,
+        'stability_stable' => Color::Green,
+        'stability_beta' => Color::Yellow,
+        'stability_alpha' => Color::Red,
+        'stability_experimental' => Color::Red,
+        'stability_test' => Color::Gray,
+        'stability_obsolete' => Color::Gray,
+        'stability_excludeFromUpdates' => Color::Gray,
+        'verified' => Color::Green,
+        'not_verified' => Color::Gray,
     ];
 
+    /**
+     * @param non-empty-string $label
+     * @param non-empty-string $message
+     */
     public function __construct(
-        private string $label = '',
-        private string $message = '',
-        private string $color = '',
+        private string $label,
+        private string $message,
+        private Color $color,
         private bool $isError = false,
     ) {
     }
 
-    public static function forExtension(string $extension): self
+    public static function static(): self
     {
         return new self(
-            label: 'extension',
-            message: $extension,
-            color: self::COLOR_MAP['extension'],
+            'typo3',
+            'inspiring people to share',
+            Color::Orange,
         );
     }
 
+    /**
+     * @param non-empty-string $extension
+     */
+    public static function forExtension(string $extension): self
+    {
+        return new self(
+            'extension',
+            $extension,
+            self::COLOR_MAP['extension'],
+        );
+    }
+
+    /**
+     * @param non-empty-string $version
+     */
     public static function forVersion(string $version): self
     {
         return new self(
-            label: 'version',
-            message: $version,
-            color: self::COLOR_MAP['version'],
+            'version',
+            $version,
+            self::COLOR_MAP['version'],
         );
     }
 
     public static function forDownloads(int $downloads): self
     {
         return new self(
-            label: 'downloads',
-            message: strtolower(NumberFormatter::format($downloads)),
-            color: self::COLOR_MAP['downloads'],
+            'downloads',
+            strtolower(NumberFormatter::format($downloads)),
+            self::COLOR_MAP['downloads'],
         );
     }
 
     /**
-     * @param list<int> $typo3Versions
+     * @param list<positive-int> $typo3Versions
      */
     public static function forTypo3Versions(array $typo3Versions): self
     {
@@ -99,58 +119,66 @@ final readonly class Badge
         sort($typo3Versions);
 
         $lastValue = array_pop($typo3Versions);
-        $typo3VersionList = implode(', ', $typo3Versions);
         $message = implode(' & ', array_filter([
-            '' !== $typo3VersionList ? $typo3VersionList : null,
+            implode(', ', $typo3Versions),
             $lastValue,
         ]));
 
         return new self(
-            label: 'typo3',
-            message: $message,
-            color: self::COLOR_MAP['typo3'],
+            'typo3',
+            $message,
+            self::COLOR_MAP['typo3'],
         );
     }
 
+    /**
+     * @param non-empty-string $stability
+     */
     public static function forStability(string $stability): self
     {
         return new self(
-            label: 'stability',
-            message: $stability,
-            color: self::COLOR_MAP['stability_'.$stability] ?? 'orange',
+            'stability',
+            $stability,
+            self::COLOR_MAP['stability_'.$stability] ?? Color::Orange,
         );
     }
 
     public static function forVerification(bool $verified): self
     {
         return new self(
-            label: 'typo3',
-            message: $verified ? 'verified' : 'not verified',
-            color: $verified ? self::COLOR_MAP['verified'] : self::COLOR_MAP['not_verified'],
+            'typo3',
+            $verified ? 'verified' : 'not verified',
+            $verified ? self::COLOR_MAP['verified'] : self::COLOR_MAP['not_verified'],
         );
     }
 
     public static function forError(): self
     {
         return new self(
-            label: 'typo3',
-            message: 'error',
-            color: self::COLOR_MAP['error'],
-            isError: true,
+            'typo3',
+            'error',
+            self::COLOR_MAP['error'],
+            true,
         );
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getLabel(): string
     {
         return $this->label;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getMessage(): string
     {
         return $this->message;
     }
 
-    public function getColor(): string
+    public function getColor(): Color
     {
         return $this->color;
     }

--- a/src/Enums/Color.php
+++ b/src/Enums/Color.php
@@ -21,37 +21,20 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace App\Value;
-
-use function array_key_exists;
-use function intval;
+namespace App\Enums;
 
 /**
- * NumberFormatter.
+ * Color.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class NumberFormatter
+enum Color
 {
-    /**
-     * @see https://gist.github.com/gcphost/589d915e2c2f67270cc9bdade732b77f
-     *
-     * @return non-empty-string
-     */
-    public static function format(int $number): string
-    {
-        if ($number < 1000) {
-            return (string) $number;
-        }
-
-        $unit = intval(log($number, 1000));
-        $units = ['', 'K', 'M', 'B', 'T', 'Q'];
-
-        if (array_key_exists($unit, $units)) {
-            return sprintf('%s%s', rtrim(number_format($number / 1000 ** $unit, 1), '.0'), $units[$unit]);
-        }
-
-        return (string) $number;
-    }
+    case Blue;
+    case Gray;
+    case Green;
+    case Orange;
+    case Red;
+    case Yellow;
 }

--- a/tests/Badge/Provider/BadgeProviderFactoryTest.php
+++ b/tests/Badge/Provider/BadgeProviderFactoryTest.php
@@ -33,7 +33,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * BadgeProviderFactoryTest.
@@ -43,12 +42,10 @@ use Symfony\Component\Routing\RouterInterface;
  */
 final class BadgeProviderFactoryTest extends KernelTestCase
 {
-    private RouterInterface $router;
     private BadgeProviderFactory $subject;
 
     protected function setUp(): void
     {
-        $this->router = self::getContainer()->get('router');
         $this->subject = new BadgeProviderFactory(
             new ServiceLocator([
                 'badgen' => fn (): BadgenBadgeProvider => self::getContainer()->get(BadgenBadgeProvider::class),
@@ -86,12 +83,11 @@ final class BadgeProviderFactoryTest extends KernelTestCase
     #[Test]
     public function getAllReturnsAllBadgeResponseProviders(): void
     {
-        $expected = [
-            'badgen' => new BadgenBadgeProvider($this->router),
-            'shields' => new ShieldsBadgeProvider($this->router),
-        ];
+        $actual = $this->subject->getAll();
 
-        self::assertEquals($expected, $this->subject->getAll());
+        self::assertCount(2, $actual);
+        self::assertInstanceOf(BadgenBadgeProvider::class, $actual['badgen'] ?? null);
+        self::assertInstanceOf(ShieldsBadgeProvider::class, $actual['shields'] ?? null);
     }
 
     /**

--- a/tests/Badge/Provider/BadgenBadgeProviderTest.php
+++ b/tests/Badge/Provider/BadgenBadgeProviderTest.php
@@ -25,6 +25,7 @@ namespace App\Tests\Badge\Provider;
 
 use App\Badge\Provider\BadgenBadgeProvider;
 use App\Entity\Badge;
+use App\Enums\Color;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,17 +45,17 @@ final class BadgenBadgeProviderTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        $this->subject = new BadgenBadgeProvider(self::getContainer()->get('router'));
+        $this->subject = self::getContainer()->get(BadgenBadgeProvider::class);
     }
 
     #[Test]
     public function createResponseReturnsResponseForBadge(): void
     {
         $badge = new Badge(
-            label: 'foo',
-            message: 'baz',
-            color: 'orange',
-            isError: true,
+            'foo',
+            'baz',
+            Color::Orange,
+            true,
         );
         $expected = new JsonResponse([
             'subject' => 'foo',

--- a/tests/Badge/Provider/ShieldsBadgeProviderTest.php
+++ b/tests/Badge/Provider/ShieldsBadgeProviderTest.php
@@ -25,6 +25,7 @@ namespace App\Tests\Badge\Provider;
 
 use App\Badge\Provider\ShieldsBadgeProvider;
 use App\Entity\Badge;
+use App\Enums\Color;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -51,10 +52,10 @@ final class ShieldsBadgeProviderTest extends KernelTestCase
     public function createResponseReturnsResponseForBadge(): void
     {
         $badge = new Badge(
-            label: 'foo',
-            message: 'baz',
-            color: 'orange',
-            isError: true,
+            'foo',
+            'baz',
+            Color::Orange,
+            true,
         );
         $expected = new JsonResponse([
             'schemaVersion' => 1,

--- a/tests/Controller/AbstractBadgeControllerTest.php
+++ b/tests/Controller/AbstractBadgeControllerTest.php
@@ -54,13 +54,13 @@ final class AbstractBadgeControllerTest extends KernelTestCase
     {
         $this->expectException(NotFoundHttpException::class);
 
-        $this->subject->testGetBadgeResponse(new Badge(), 'foo');
+        $this->subject->testGetBadgeResponse(Badge::static(), 'foo');
     }
 
     #[Test]
     public function getBadgeResponseReturnsResponseForDefaultProviderIfNoProviderIsGiven(): void
     {
-        $badge = new Badge();
+        $badge = Badge::static();
         $expected = $this->badgeProviderFactory->get()->createResponse($badge);
 
         self::assertEquals($expected, $this->subject->testGetBadgeResponse($badge));
@@ -69,7 +69,7 @@ final class AbstractBadgeControllerTest extends KernelTestCase
     #[Test]
     public function getBadgeResponseReturnsResponseForRequestedProvider(): void
     {
-        $badge = new Badge();
+        $badge = Badge::static();
         $expected = $this->badgeProviderFactory->get('badgen')->createResponse($badge);
 
         self::assertEquals($expected, $this->subject->testGetBadgeResponse($badge, 'badgen'));
@@ -78,7 +78,7 @@ final class AbstractBadgeControllerTest extends KernelTestCase
     #[Test]
     public function getBadgeResponseReturnsCachedResponse(): void
     {
-        $badge = new Badge();
+        $badge = Badge::static();
         $cacheExpirationDate = new DateTime();
         $expected = $this->badgeProviderFactory->get('badgen')->createResponse($badge)
             ->setPublic()

--- a/tests/Entity/BadgeTest.php
+++ b/tests/Entity/BadgeTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity;
 
 use App\Entity\Badge;
+use App\Enums\Color;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -41,10 +42,10 @@ final class BadgeTest extends TestCase
     public function forExtensionReturnsBadgeForExtension(): void
     {
         $expected = new Badge(
-            label: 'extension',
-            message: 'foo',
-            color: 'orange',
-            isError: false,
+            'extension',
+            'foo',
+            Color::Orange,
+            false,
         );
 
         self::assertEquals($expected, Badge::forExtension('foo'));
@@ -54,10 +55,10 @@ final class BadgeTest extends TestCase
     public function forVersionReturnsBadgeForVersion(): void
     {
         $expected = new Badge(
-            label: 'version',
-            message: '1.0.0',
-            color: 'orange',
-            isError: false,
+            'version',
+            '1.0.0',
+            Color::Orange,
+            false,
         );
 
         self::assertEquals($expected, Badge::forVersion('1.0.0'));
@@ -67,10 +68,10 @@ final class BadgeTest extends TestCase
     public function forDownloadsReturnsBadgeForDownloads(): void
     {
         $expected = new Badge(
-            label: 'downloads',
-            message: '845.8m',
-            color: 'blue',
-            isError: false,
+            'downloads',
+            '845.8m',
+            Color::Blue,
+            false,
         );
 
         self::assertEquals($expected, Badge::forDownloads(845760473));
@@ -85,31 +86,35 @@ final class BadgeTest extends TestCase
     }
 
     /**
-     * @param list<int> $typo3Versions
+     * @param list<positive-int> $typo3Versions
+     * @param non-empty-string   $expected
      */
     #[Test]
     #[DataProvider('forTypo3VersionsReturnsBadgeForTypo3VersionsDataProvider')]
     public function forTypo3VersionsReturnsBadgeForTypo3Versions(array $typo3Versions, string $expected): void
     {
         $expected = new Badge(
-            label: 'typo3',
-            message: $expected,
-            color: 'orange',
-            isError: false,
+            'typo3',
+            $expected,
+            Color::Orange,
+            false,
         );
 
         self::assertEquals($expected, Badge::forTypo3Versions($typo3Versions));
     }
 
+    /**
+     * @param non-empty-string $stability
+     */
     #[Test]
     #[DataProvider('forStabilityReturnsBadgeForStabilityDataProvider')]
-    public function forStabilityReturnsBadgeForStability(string $stability, string $expectedColor): void
+    public function forStabilityReturnsBadgeForStability(string $stability, Color $expectedColor): void
     {
         $expected = new Badge(
-            label: 'stability',
-            message: $stability,
-            color: $expectedColor,
-            isError: false,
+            'stability',
+            $stability,
+            $expectedColor,
+            false,
         );
 
         self::assertEquals($expected, Badge::forStability($stability));
@@ -119,10 +124,10 @@ final class BadgeTest extends TestCase
     public function forErrorReturnsBadgeOnError(): void
     {
         $expected = new Badge(
-            label: 'typo3',
-            message: 'error',
-            color: 'red',
-            isError: true,
+            'typo3',
+            'error',
+            Color::Red,
+            true,
         );
 
         self::assertEquals($expected, Badge::forError());
@@ -131,11 +136,12 @@ final class BadgeTest extends TestCase
     #[Test]
     public function getLabelReturnsLabel(): void
     {
-        $subject = new Badge();
-
-        self::assertSame('', $subject->getLabel());
-
-        $subject = new Badge(label: 'foo');
+        $subject = new Badge(
+            'foo',
+            'baz',
+            Color::Orange,
+            false,
+        );
 
         self::assertSame('foo', $subject->getLabel());
     }
@@ -143,55 +149,58 @@ final class BadgeTest extends TestCase
     #[Test]
     public function getMessageReturnsMessage(): void
     {
-        $subject = new Badge();
+        $subject = new Badge(
+            'foo',
+            'baz',
+            Color::Orange,
+            false,
+        );
 
-        self::assertSame('', $subject->getMessage());
-
-        $subject = new Badge(message: 'foo');
-
-        self::assertSame('foo', $subject->getMessage());
+        self::assertSame('baz', $subject->getMessage());
     }
 
     #[Test]
     public function getColorReturnsColor(): void
     {
-        $subject = new Badge();
+        $subject = new Badge(
+            'foo',
+            'baz',
+            Color::Orange,
+            false,
+        );
 
-        self::assertSame('', $subject->getColor());
-
-        $subject = new Badge(color: 'foo');
-
-        self::assertSame('foo', $subject->getColor());
+        self::assertSame(Color::Orange, $subject->getColor());
     }
 
     #[Test]
     public function isErrorReturnsErrorState(): void
     {
-        $subject = new Badge();
-
-        self::assertFalse($subject->isError());
-
-        $subject = new Badge(isError: true);
+        $subject = new Badge(
+            'foo',
+            'baz',
+            Color::Orange,
+            true,
+        );
 
         self::assertTrue($subject->isError());
     }
 
     /**
-     * @return \Generator<string, array{string, string}>
+     * @return \Generator<string, array{non-empty-string, Color}>
      */
     public static function forStabilityReturnsBadgeForStabilityDataProvider(): Generator
     {
-        yield 'stable' => ['stable', 'green'];
-        yield 'beta' => ['beta', 'yellow'];
-        yield 'alpha' => ['alpha', 'red'];
-        yield 'experimental' => ['experimental', 'red'];
-        yield 'test' => ['test', 'lightgrey'];
-        yield 'obsolete' => ['obsolete', 'lightgrey'];
-        yield 'excludeFromUpdates' => ['excludeFromUpdates', 'lightgrey'];
+        yield 'stable' => ['stable', Color::Green];
+        yield 'beta' => ['beta', Color::Yellow];
+        yield 'alpha' => ['alpha', Color::Red];
+        yield 'experimental' => ['experimental', Color::Red];
+        yield 'test' => ['test', Color::Gray];
+        yield 'obsolete' => ['obsolete', Color::Gray];
+        yield 'excludeFromUpdates' => ['excludeFromUpdates', Color::Gray];
     }
 
     /**
-     * @return \Generator<string, array{list<int>, string}>
+     * @return \Generator<string, array{list<positive-int>, non-empty-string}>
      */
     public static function forTypo3VersionsReturnsBadgeForTypo3VersionsDataProvider(): Generator
     {


### PR DESCRIPTION
Since color values are different between badge providers, each provider now handles the values by its own. For this, a new `Color` enum is added. In addition, the badge entity properties are hardened a little bit.