### PR TITLE
[BUGFIX] Improve extension key handling in try-out section on mobile

### DIFF
--- a/assets/js/badge/tryOut.js
+++ b/assets/js/badge/tryOut.js
@@ -82,7 +82,7 @@ export default class TryOut {
     this.element.querySelector('form').onsubmit = (e) => {
       e.preventDefault();
 
-      const extensionKey = this.input.value;
+      const extensionKey = this.input.value.trim().toLowerCase();
       this.applyTemplate(extensionKey);
     };
   }

--- a/templates/homepage/try-out.html.twig
+++ b/templates/homepage/try-out.html.twig
@@ -18,7 +18,7 @@
                 <h3 class="text-xl font-bold">&#x26A1;&nbsp;Create your TYPO3 badges</h3>
                 <div>
                     <label for="try-out-extension-key" class="block mb-2 text-sm font-medium text-gray-900">Extension key</label>
-                    <input type="text" name="try-out-extension-key" id="try-out-extension-key" class="shadow-md outline-none w-full border border-gray-100 text-gray-700 hover:bg-gray-50 focus:ring-4 focus:ring-orange-300 font-medium rounded-md text-sm px-4 py-2" placeholder="e.g. {{ randomExtensionKey }}" required>
+                    <input type="text" name="try-out-extension-key" id="try-out-extension-key" autocomplete="off" autocapitalize="off" spellcheck="false" class="shadow-md outline-none w-full border border-gray-100 text-gray-700 hover:bg-gray-50 focus:ring-4 focus:ring-orange-300 font-medium rounded-md text-sm px-4 py-2" placeholder="e.g. {{ randomExtensionKey }}" required>
                 </div>
                 <div class="flex justify-between space-x-2">
                     <button type="submit" class="js-hidden shadow-md text-white bg-red-500 hover:bg-red-600 focus:ring-4 focus:ring-orange-300 font-medium rounded-md text-sm px-4 py-2 text-center inline-flex items-center">


### PR DESCRIPTION
This PR addresses some issues with the "extension key" input field within the try-out section on mobile devices.