### PR TITLE
[TASK] Use Deployer preset from global Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"local>eliashaeussler/renovate-config"
-	],
-	"regexManagers": [
-		{
-			"fileMatch": [
-				"^\\.github/workflows/deploy\\.yaml$"
-			],
-			"matchStrings": [
-				"deployer-version: '(?<currentValue>[^']+)'"
-			],
-			"datasourceTemplate": "packagist",
-			"depNameTemplate": "deployer/deployer"
-		}
+		"local>eliashaeussler/renovate-config",
+		"local>eliashaeussler/renovate-config:deployer"
 	]
 }


### PR DESCRIPTION
This PR includes the `deployer` preset from `eliashaeussler/renovate-config`. It replaces the local config for Deployer version updates.