### PR TITLE
[TASK] Use config API from `eliashaeussler/phpstan-config`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /codecov.yml              export-ignore
 /CODEOWNERS               export-ignore
 /deploy.php               export-ignore
-/phpstan.neon             export-ignore
+/phpstan.php              export-ignore
 /phpunit.xml              export-ignore
 /rector.php               export-ignore
 /renovate.json            export-ignore

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
 		"lint:composer": "@fix:composer --dry-run",
 		"lint:php": "@fix:php --dry-run",
 		"migration": "rector process",
-		"sca": "phpstan analyse -c phpstan.neon",
+		"sca": "phpstan analyse -c phpstan.php",
 		"test": "@test:coverage --no-coverage",
 		"test:coverage": "phpunit -c phpunit.xml"
 	}

--- a/deploy.php
+++ b/deploy.php
@@ -52,7 +52,7 @@ set('rsync', [
         'codecov.yml',
         'CODEOWNERS',
         'deploy.php',
-        'phpstan.neon',
+        'phpstan.php',
         'phpunit.xml',
         'postcss.config.js',
         'rector.php',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,0 @@
-includes:
-	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
-parameters:
-	level: 8
-	paths:
-		- src
-		- tests
-	symfony:
-		containerXmlPath: var/cache/dev/App_KernelDevDebugContainer.xml

--- a/phpstan.php
+++ b/phpstan.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use EliasHaeussler\PHPStanConfig;
+
+$symfonySet = PHPStanConfig\Set\SymfonySet::create()
+    ->withContainerXmlPath('var/cache/dev/App_KernelDevDebugContainer.xml')
+;
+
+return PHPStanConfig\Config\Config::create(__DIR__)
+    ->in(
+        'src',
+        'tests',
+    )
+    ->withBleedingEdge()
+    ->withSets($symfonySet)
+    ->level(8)
+    ->toArray()
+;


### PR DESCRIPTION
This PR replaces the `phpstan.neon` file by a `phpstan.php` file which uses the config API from `eliashaeussler/phpstan-config`.