### PR TITLE
[FEATURE] Add Composer badge

### DIFF
--- a/spec/typo3-badges.oas3.yaml
+++ b/spec/typo3-badges.oas3.yaml
@@ -39,6 +39,31 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
+  /badge/{extension}/composer/{provider}:
+    get:
+      description: Composer badge
+      summary: >-
+        Gets badge data for Composer name of given TYPO3 extension using the
+        default badge provider.
+      operationId: getComposerBadge
+      parameters:
+        - $ref: '#/components/parameters/Extension'
+        - $ref: '#/components/parameters/Provider'
+      tags:
+        - Badge
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/BadgenResponse'
+                  - $ref: '#/components/schemas/ShieldsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /badge/{extension}/downloads/{provider}:
     get:
       description: Downloads badge

--- a/src/Controller/ComposerBadgeController.php
+++ b/src/Controller/ComposerBadgeController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2021-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Controller;
+
+use App\Entity\Badge;
+use App\Service\ApiService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * ComposerBadgeController.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Route(
+    path: '/badge/{extension}/composer/{provider?}.{_format}',
+    name: 'badge.composer',
+    requirements: [
+        'extension' => '[a-z0-9_]+',
+        '_format' => 'json|svg',
+    ],
+    options: [
+        'title' => 'Composer',
+        'description' => 'Get JSON data for Composer name.',
+    ],
+    methods: ['GET'],
+    format: 'json',
+)]
+final class ComposerBadgeController extends AbstractBadgeController
+{
+    public function __construct(
+        private readonly ApiService $apiService,
+    ) {}
+
+    public function __invoke(Request $request, string $extension, string $provider = null): Response
+    {
+        $extensionMetadata = $this->apiService->getExtensionMetadata($extension);
+        $composerName = $extensionMetadata[0]['meta']['composer_name'] ?? null;
+
+        return $this->getBadgeResponse(
+            $request,
+            Badge::forComposerName($composerName),
+            $provider,
+            $extensionMetadata->getExpiryDate(),
+        );
+    }
+}

--- a/src/Entity/Badge.php
+++ b/src/Entity/Badge.php
@@ -38,6 +38,8 @@ final readonly class Badge
 {
     /** @var array<string, Color> */
     private const array COLOR_MAP = [
+        'composer' => Color::Blue,
+        'composer_undefined' => Color::Gray,
         'extension' => Color::Orange,
         'version' => Color::Orange,
         'downloads' => Color::Blue,
@@ -71,6 +73,23 @@ final readonly class Badge
             'typo3',
             'inspiring people to share',
             Color::Orange,
+        );
+    }
+
+    public static function forComposerName(?string $composerName): self
+    {
+        if (null === $composerName || '' === $composerName) {
+            return new self(
+                'composer',
+                'unknown',
+                self::COLOR_MAP['composer_undefined'],
+            );
+        }
+
+        return new self(
+            'composer',
+            $composerName,
+            self::COLOR_MAP['composer'],
         );
     }
 

--- a/tests/Controller/ComposerBadgeControllerTest.php
+++ b/tests/Controller/ComposerBadgeControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony project "eliashaeussler/typo3-badges".
+ *
+ * Copyright (C) 2021-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Badge\Provider\BadgeProviderFactory;
+use App\Controller\ComposerBadgeController;
+use App\Tests\AbstractApiTestCase;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+use function json_encode;
+
+/**
+ * ComposerBadgeControllerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ComposerBadgeControllerTest extends AbstractApiTestCase
+{
+    private ComposerBadgeController $subject;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new ComposerBadgeController($this->apiService);
+        $this->subject->setBadgeProviderFactory(self::getContainer()->get(BadgeProviderFactory::class));
+    }
+
+    #[Test]
+    public function controllerReturnsBadgeForUnknownComposerName(): void
+    {
+        $this->mockResponses[] = new MockResponse(json_encode([
+            [
+                'meta' => [
+                    'composer_name' => '',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $expected = new JsonResponse([
+            'schemaVersion' => 1,
+            'label' => 'composer',
+            'message' => 'unknown',
+            'color' => 'lightgrey',
+            'isError' => false,
+            'namedLogo' => 'typo3',
+        ]);
+
+        self::assertSame(
+            $expected->getContent(),
+            ($this->subject)(new Request(), 'foo')->getContent(),
+        );
+    }
+
+    #[Test]
+    public function controllerReturnsBadgeForGivenExtension(): void
+    {
+        $this->mockResponses[] = new MockResponse(json_encode([
+            [
+                'meta' => [
+                    'composer_name' => 'foo/baz',
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $expected = new JsonResponse([
+            'schemaVersion' => 1,
+            'label' => 'composer',
+            'message' => 'foo/baz',
+            'color' => 'blue',
+            'isError' => false,
+            'namedLogo' => 'typo3',
+        ]);
+
+        self::assertSame(
+            $expected->getContent(),
+            ($this->subject)(new Request(), 'foo')->getContent(),
+        );
+    }
+}

--- a/tests/Entity/BadgeTest.php
+++ b/tests/Entity/BadgeTest.php
@@ -39,6 +39,32 @@ use PHPUnit\Framework\TestCase;
 final class BadgeTest extends TestCase
 {
     #[Test]
+    public function forComposerNameReturnsBadgeForUnknownComposerName(): void
+    {
+        $expected = new Badge(
+            'composer',
+            'unknown',
+            Color::Gray,
+            false,
+        );
+
+        self::assertEquals($expected, Badge::forComposerName(null));
+    }
+
+    #[Test]
+    public function forComposerNameReturnsBadgeForGivenComposerName(): void
+    {
+        $expected = new Badge(
+            'composer',
+            'foo/baz',
+            Color::Blue,
+            false,
+        );
+
+        self::assertEquals($expected, Badge::forComposerName('foo/baz'));
+    }
+
+    #[Test]
     public function forExtensionReturnsBadgeForExtension(): void
     {
         $expected = new Badge(


### PR DESCRIPTION
This PR adds a new badge that provides the Composer name of a given extension:

```
GET /badge/{extension}/composer/{provider}.{_format}
```