### PR TITLE
[BUGFIX] Migrate space-y with hidden children to flex + gap

### DIFF
--- a/templates/homepage/try-out.html.twig
+++ b/templates/homepage/try-out.html.twig
@@ -14,7 +14,7 @@
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
                 </button>
             </div>
-            <form class="px-6 py-4 space-y-6 lg:px-8 sm:py-6 xl:py-8" action="#">
+            <form class="px-6 py-4 flex flex-col gap-6 lg:px-8 sm:py-6 xl:py-8" action="#">
                 <h3 class="text-xl font-bold"><span aria-hidden="true" role="presentation">&#x26A1;&nbsp;</span>Create your TYPO3 badges</h3>
                 <div>
                     <label for="try-out-extension-key" class="block mb-2 text-sm font-medium text-gray-900">Extension key</label>


### PR DESCRIPTION
See [^1] for reference.

[^1]: https://tailwindcss.com/docs/upgrade-guide#space-between-selector