### PR TITLE
[BUGFIX] Don't create releases on workflow dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: 'Create release'
 
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
     permissions:
       contents: write
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to only create releases when triggered by tag pushes, preventing unintended release triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->